### PR TITLE
Adicionado pool no firebird

### DIFF
--- a/DELPHI/DelphiMormot/DelphiMormot.dpr
+++ b/DELPHI/DelphiMormot/DelphiMormot.dpr
@@ -95,12 +95,16 @@ begin
 end;
 
 procedure CriarConexao(AcBanco: RawUTF8);
+var
+  i: integer;
 begin
   FoFirebirdDB := TSQLDBFireDACConnectionProperties.Create(
                   FIREDAC_PROVIDER[dFirebird],
                   AcBanco,
                   'sysdba',
                   'masterkey');
+  for i := 0 to 100 do
+    FoFirebirdDB.NewConnection;
 end;
 
 begin


### PR DESCRIPTION
Coloquei 100 no pool, porem na minha máquina após iniciar as chamadas o firebird limita a 50, não sei se é alguma configuração do meu firebird mas não consegui passar de 50.